### PR TITLE
Update to fix unexpected API argument when trying to rename files

### DIFF
--- a/info.json
+++ b/info.json
@@ -11,5 +11,5 @@
         "on_postprocessor_task_results": 0
     },
     "tags": "sonarr",
-    "version": "0.0.5"
+    "version": "0.0.6"
 }

--- a/plugin.py
+++ b/plugin.py
@@ -159,7 +159,7 @@ def update_mode(api, dest_path, rename_files):
     if rename_files:
         time.sleep(10) # Must give time (more than Radarr) for the refresh to complete before we run the rename.
         try:
-            rename_list = api.get_episode_file(series_id, series=True)
+            rename_list = api.get_episode_files_by_series_id(series_id)
             file_ids = [episode['id'] for episode in rename_list]
             result = api.post_command('RenameFiles', seriesId=series_id, files=file_ids)
             if isinstance(result, dict):


### PR DESCRIPTION
Updated plugin.py to use a different API call to get episode files that doesn't use an optional argument seemingly unsupported by Sonarr which caused an error.